### PR TITLE
Ensure that Hydra Can Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+        compiler: [gcc, clang]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Build Hydra 0.1.8
+        env:
+          CC: ${{ matrix.compiler }}
+        run: |
+          cd src
+          ./configure
+          make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [ubuntu-latest]
         compiler: [gcc, clang]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Install dependency
+        run: |
+          sudo apt-get install -y libgnutls28-dev
       - name: Build Hydra 0.1.8
         env:
           CC: ${{ matrix.compiler }}
         run: |
-          cd src
           ./configure
           make

--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 [Hydra](http://hydra.hellug.gr/) is a lightweight, multithreaded HTTP(S) server based on [Boa](https://github.com/shrug-security/boa-0.94.13) which is occasionally still found in embedded firmware images for serving CGI scripts, files, and more. 0.1.8 is the last stable version, and was released [in 2006](http://hydra.hellug.gr/download/).
 
-## Known Vulnerabilities
+### Known Vulnerabilities
 
 - [CVE-2019-17502](https://www.cvedetails.com/cve/CVE-2019-17502/) - Discovered by [Felix Blanco](https://github.com/fxb6476): Hydra through 0.1.8 has a NULL pointer dereference & daemon crash when processing POST requests that lack a 'Content-Length' header. Links: [disclosure](https://gist.github.com/fxb6476/0b9883a88ff2ca40de46a8469834e16c).
+
+### Changelog
+
+* [PR #1](https://github.com/shrug-security/hydra-0.1.8/pull/1) adds CI to build Hydra on every pull or PR.
 
 ### Warranty & Liability
 


### PR DESCRIPTION
Practicing incremental improvements for demonstrative purposes, this starts with the first, critical thing to do when working with old software: **can you get it to build**.

If you can't for any reason, you may spend a lot of time on something that is eventually fruitless. Reasons something won't build range from "you made an error when building" to "you'll need an older version of a library" to "something is missing that was maintained by one guy in Nebraska who eventually died."

Hydra is simple - it needs GnuTLS, which is developed to this day. That's it. We'll build it on Ubuntu using GitHub Actions after every code push or PR.