### PR TITLE
Adds starter SAST

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,10 +4,7 @@ on: [push, pull_request]
 
 jobs:
   lint:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -42,4 +42,4 @@ jobs:
           sudo ln -s "/opt/infer-linux64-v$VERSION/bin/infer" /usr/local/bin/infer
           ./configure
           infer --progress-bar-style plain --quiet -- make
-          cat infer-out/bugs.txt
+          cat infer-out/report.txt

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -1,0 +1,45 @@
+name: sast
+
+on: [push, pull_request]
+
+jobs:
+  flawfinder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install dependency
+        run: |
+          sudo apt-get install -y flawfinder
+      - name: Runs flawfinder
+        run: |
+          flawfinder .
+
+  cppcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install dependency
+        run: |
+          sudo apt-get install -y cppcheck
+      - name: Runs cppcheck
+        run: |
+          cppcheck --force .
+
+  infer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install dependency
+        run: |
+          sudo apt-get install -y libgnutls28-dev libstdc++6
+      - name: Runs Infer
+        run: |
+          VERSION=1.1.0
+          curl -sSL "https://github.com/facebook/infer/releases/download/v$VERSION/infer-linux64-v$VERSION.tar.xz" | sudo tar -C /opt -xJ
+          sudo ln -s "/opt/infer-linux64-v$VERSION/bin/infer" /usr/local/bin/infer
+          ./configure
+          infer --progress-bar-style plain --quiet -- make
+          cat infer-out/bugs.txt

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 ### Changelog
 
-* [PR #1](https://github.com/shrug-security/hydra-0.1.8/pull/1) adds CI to build Hydra on every pull or PR.
-* [PR #2](https://github.com/shrug-security/hydra-0.1.8/pull/2) adds `clang-format` configuration and reformats all files to follow.
+* **Cleaning up**: [PR #1](https://github.com/shrug-security/hydra-0.1.8/pull/1) adds CI to build Hydra on every pull or PR.
+* **Cleaning up**: [PR #2](https://github.com/shrug-security/hydra-0.1.8/pull/2) adds `clang-format` configuration and reformats all files to follow.
 
 ### Warranty & Liability
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 * **Cleaning up**: [PR #1](https://github.com/shrug-security/hydra-0.1.8/pull/1) adds CI to build Hydra on every pull or PR.
 * **Cleaning up**: [PR #2](https://github.com/shrug-security/hydra-0.1.8/pull/2) adds `clang-format` configuration and reformats all files to follow.
+* **Security analysis**: [PR #3](https://github.com/shrug-security/hydra-0.1.8/pull/3) adds three SAST tools to CI, to assist in finding security issues.
 
 ### Warranty & Liability
 


### PR DESCRIPTION
Now that we've cleaned up a bit, let's start adding security analyzers. You don't want to go out of your way to add every single SAST tool in the world, or you'll drown yourself in pointless, garbage alerts. SAST tools can be prone to false positives or false negatives and "more" is **not** universally "better."

Our starting picks are:

* [flawfinder](https://dwheeler.com/flawfinder/) is a fast and easy-to-use security linter, which focuses on finding common security problems with C programs. Specifically, flawfinder looks for well-known problems, such as buffer overflow risks (think `strcpy`), filters out probably false positives such as static text based on *some* flow analysis, and then produces a list of hits sorted by severity.
* [cppcheck](https://cppcheck.sourceforge.io/) is a static analyzer less focused on security, and more focused on finding undefined behavior. However, many security bugs are caused by undefined behavior - cppcheck in the hands of experts is responsible for finding many CVEs in its own right - and this can help us identify or confirm other security issues by highlighting problem areas.
* [infer](https://fbinfer.com/) is the final and smartest static analyzer of the lot, coming from Facebook after their Monoidics acquisition. It uses Certifiably Cool Math to reason about how programs are interacting with memory, and uses that to find security issues including null pointer dereferences and memory leaks. It is almost certainly the most accurate of the lot, however the detections it has are also the most specific.

There are other options - good options even - but we won't be including them at this time. In addition, all of these programs are running in CI and only displaying their results in GitHub Actions. This is fine for you and I - security-interested people working on an isolated project - but wouldn't often be useful to put in front of developers, especially if you break their build with so little information on how to fix the issue (if there even is an issue in the first place).

Next, we'll check what did and didn't find the known CVE in hydra 0.1.8.