### PR TITLE
Fix CVE-2019-17502

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Hydra](http://hydra.hellug.gr/) is a lightweight, multithreaded HTTP(S) server based on [Boa](https://github.com/shrug-security/boa-0.94.13) which is occasionally still found in embedded firmware images for serving CGI scripts, files, and more. 0.1.8 is the last stable version, and was released [in 2006](http://hydra.hellug.gr/download/).
 
-### Known Vulnerabilities
+### Fixed Vulnerabilities
 
 - [CVE-2019-17502](https://www.cvedetails.com/cve/CVE-2019-17502/) - Discovered by [Felix Blanco](https://github.com/fxb6476): Hydra through 0.1.8 has a NULL pointer dereference & daemon crash when processing POST requests that lack a 'Content-Length' header. Links: [disclosure](https://gist.github.com/fxb6476/0b9883a88ff2ca40de46a8469834e16c).
 
@@ -11,6 +11,7 @@
 * **Cleaning up**: [PR #1](https://github.com/shrug-security/hydra-0.1.8/pull/1) adds CI to build Hydra on every pull or PR.
 * **Cleaning up**: [PR #2](https://github.com/shrug-security/hydra-0.1.8/pull/2) adds `clang-format` configuration and reformats all files to follow.
 * **Security analysis**: [PR #3](https://github.com/shrug-security/hydra-0.1.8/pull/3) adds three SAST tools to CI, to assist in finding security issues.
+* **Vulnerability fixed**: [PR #4](https://github.com/shrug-security/hydra-0.1.8/pull/4) fixes CVE-2019-17502, an NPD in src/util.c affecting boa_atoi().
 
 ### Warranty & Liability
 

--- a/src/util.c
+++ b/src/util.c
@@ -432,14 +432,11 @@ int create_etag(unsigned long int size, unsigned long int mod_time,
  */
 
 int boa_atoi(const char *s) {
-  if (!s) { /* Check for null pointer; fixes CVE-2019-17502 */
-    return -1;
-  }
+  if (!s) return -1; /* Check for null pointer; fixes CVE-2019-17502 */
+  if (!isdigit(*s)) return -1;
 
   int retval;
   char reconv[22];
-
-  if (!isdigit(*s)) return -1;
 
   retval = atoi(s);
   if (retval < 0) return -1;

--- a/src/util.c
+++ b/src/util.c
@@ -432,6 +432,10 @@ int create_etag(unsigned long int size, unsigned long int mod_time,
  */
 
 int boa_atoi(const char *s) {
+  if (!s) { /* Check for null pointer; fixes CVE-2019-17502 */
+    return -1;
+  }
+
   int retval;
   char reconv[22];
 


### PR DESCRIPTION
## The Problem

As stated by Felix Blanco's [disclosure](https://gist.github.com/fxb6476/0b9883a88ff2ca40de46a8469834e16c) (includes proof-of-concept):

Hydra added additional code to Boa's process_header_end() function. The additional code makes a call to the boa_atoi() function with req->content_length variable as an argument.

The value of req->content_length is supposed to be set by the function process_option_line(), which sets it to the numerical value after the 'Content-Length: ' header. However, if the 'Content-Length' header is omitted from the POST request, the value of req->content_length remains NULL.
   
Finally, after the call to process_option_line(), read.c makes a call to the process_header_end() function. The additional code added by Hydra in process_head_end(), then makes an unchecked call to boa_atoi() passing req->content_length as a parameter, which is NULL. Inside boa_atoi() the atoi() function is called as follows, atoi(req->content_length) -> atoi(NULL). This results in the segment fault exception being thrown, and the Hydra daemon crashing.

### Discovery Notes

flawfinder issues a warning for use of atoi() in hydra. Other SAST tools in our pipeline don't issue a warning.

## The Solution

Checking if a pointer is NULL in C is simple ([StackOverflow](https://stackoverflow.com/questions/3825668/checking-for-null-pointer-in-c-c)). While we could solve this issue anywhere in the affected code pathway (for example, checking if req->content_length is NULL in process_header_end()), I've chosen to solve this issue by addressing it in the vulnerable function specifically - killing the vulnerability in the commonly-used building block, so other pathways to this vulnerability which could be discovered later are not vulnerable *either*. At the beginning of boa_atoi(), we now include a check to see if the input *s is NULL, preventing NPD by the later atoi() call:

```
...
int boa_atoi(const char *s) {
  if (!s) return -1; /* Check for null pointer; fixes CVE-2019-17502 */
...
```